### PR TITLE
Add quantization

### DIFF
--- a/sam.lua
+++ b/sam.lua
@@ -70,7 +70,6 @@ local function quantize_loop_len()
     params:set("loop_end", loop_start + (q_beat_len * q_beat_count))
     quantized_time = util.time()
   else
-    print("loop too short for quantization settings")
     quantized_err_time = util.time()
   end
 end


### PR DESCRIPTION
while not recording, alt (hold k1) + k2.

snaps end point up or down to fit in the maximum # of beats according to clock's BPM. the quantize div parameter needs some work; that's up next!

remove the additional if statement if the desired behavior is to only trim down (which means the quantized result will never be longer than your initial manually-set loop (no dead air). or heck, make it a setting.